### PR TITLE
Fixed file path for config.fish, for proper verification and command append

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,11 +45,11 @@ if [[ -f "$HOME/.bashrc" || -L "$HOME/.bashrc" ]]; then
    fi
 fi
 
-if [[ -f "$HOME/.config/config.fish" || -L "$HOME/.config/config.fish" ]]; then
-   if ! grep -q ".backdrop/bin" "$HOME/.config/config.fish"; then
+if [[ -f "$HOME/.config/fish/config.fish" || -L "$HOME/.config/fish/config.fish" ]]; then
+   if ! grep -q ".backdrop/bin" "$HOME/.config/fish/config.fish"; then
       echo ''
       echo "Backdrop not in config.fish, adding PATH."
-      append_backdrop_to_path ".config/config.fish"
+      append_backdrop_to_path ".config/fish/config.fish"
    fi
 fi
 


### PR DESCRIPTION
Install script was missing `fish` folder in the append function for proper verification. File path was corrected.